### PR TITLE
Change the default jenkins parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,9 @@ properties([
   disableConcurrentBuilds(),
   parameters([
     string(name: 'THREADS', defaultValue: '100'),
-    string(name: 'DURATION', defaultValue: '300'),
-    string(name: 'API_HOST', defaultValue: 'api-stage.santiment.net'),
-    string(name: 'PROTOCOL', defaultValue: 'https'),
+    string(name: 'DURATION', defaultValue: '180'),
+    string(name: 'API_HOST', defaultValue: 'sanbase'),
+    string(name: 'PROTOCOL', defaultValue: 'http'),
   ])
 ])
 podTemplate(label: 'performace_tests', containers: [


### PR DESCRIPTION
- Change to http and sanbase so the cronjob will use them and not get rate limited.
- Change to 180 seconds as it's also enough - longer tests can be ran from
jenkins. Main reason for change is that every brahch/PR runs all tests
and can take a lot of time to build